### PR TITLE
Add support for 6 Kubernetes workload resources with Prometheus metrics

### DIFF
--- a/cmd/rampaz-server/main.go
+++ b/cmd/rampaz-server/main.go
@@ -49,15 +49,19 @@ func main() {
 	daemonSetClient := kubernetes.NewDaemonSetClient(clients.Kube)
 	daemonSetService := service.NewDaemonSetService(daemonSetClient)
 
+	statefulSetClient := kubernetes.NewStatefulSetClient(clients.Kube)
+	statefulSetService := service.NewStatefulSetService(statefulSetClient)
+
 	handler := &api.K8SServer{
-		PodService:        podService,
-		NodeService:       nodeService,
-		EventService:      eventService,
-		PodMetService:     podMetService,
-		NodeMetService:    nodeMetService,
-		DeploymentService: deploymentService,
-		ReplicaSetservice: replicaSetService,
-		DaemonSetService:  daemonSetService,
+		PodService:         podService,
+		NodeService:        nodeService,
+		EventService:       eventService,
+		PodMetService:      podMetService,
+		NodeMetService:     nodeMetService,
+		DeploymentService:  deploymentService,
+		ReplicaSetservice:  replicaSetService,
+		DaemonSetService:   daemonSetService,
+		StatefulSetService: statefulSetService,
 	}
 
 	fmt.Printf("server is running on port: 50052 \n")

--- a/cmd/rampaz-server/main.go
+++ b/cmd/rampaz-server/main.go
@@ -52,6 +52,12 @@ func main() {
 	statefulSetClient := kubernetes.NewStatefulSetClient(clients.Kube)
 	statefulSetService := service.NewStatefulSetService(statefulSetClient)
 
+	jobClient := kubernetes.NewJobClient(clients.Kube)
+	jobService := service.NewJobService(jobClient)
+
+	cronJobClient := kubernetes.NewCronJobClient(clients.Kube)
+	cronJobService := service.NewCronJobService(cronJobClient)
+
 	handler := &api.K8SServer{
 		PodService:         podService,
 		NodeService:        nodeService,
@@ -62,6 +68,8 @@ func main() {
 		ReplicaSetservice:  replicaSetService,
 		DaemonSetService:   daemonSetService,
 		StatefulSetService: statefulSetService,
+		JobService:         jobService,
+		CronJobService:     cronJobService,
 	}
 
 	fmt.Printf("server is running on port: 50052 \n")

--- a/cmd/rampaz-server/main.go
+++ b/cmd/rampaz-server/main.go
@@ -40,12 +40,24 @@ func main() {
 	nodeMetricsClient := kubernetes.NewNodeMetricsClient(clients.Metrics)
 	nodeMetService := service.NewNodeMetService(nodeMetricsClient)
 
+	deploymentClient := kubernetes.NewDeploymentClient(clients.Kube)
+	deploymentService := service.NewDeploymentService(deploymentClient)
+
+	replicaSetClient := kubernetes.NewReplicaSetClient(clients.Kube)
+	replicaSetService := service.NewReplicaSetService(replicaSetClient)
+
+	daemonSetClient := kubernetes.NewDaemonSetClient(clients.Kube)
+	daemonSetService := service.NewDaemonSetService(daemonSetClient)
+
 	handler := &api.K8SServer{
-		PodService:     podService,
-		NodeService:    nodeService,
-		EventService:   eventService,
-		PodMetService:  podMetService,
-		NodeMetService: nodeMetService,
+		PodService:        podService,
+		NodeService:       nodeService,
+		EventService:      eventService,
+		PodMetService:     podMetService,
+		NodeMetService:    nodeMetService,
+		DeploymentService: deploymentService,
+		ReplicaSetservice: replicaSetService,
+		DaemonSetService:  daemonSetService,
 	}
 
 	fmt.Printf("server is running on port: 50052 \n")

--- a/internal/api/cronjob_handler.go
+++ b/internal/api/cronjob_handler.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (s *K8SServer) ListCronJobs(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := s.CronJobService.List(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/cronjob_handler.go
+++ b/internal/api/cronjob_handler.go
@@ -3,13 +3,27 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (s *K8SServer) ListCronJobs(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
+	endpoint := "list_cronjobs"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
 	workloads, err := s.CronJobService.List(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/api/daemonset_handler.go
+++ b/internal/api/daemonset_handler.go
@@ -3,13 +3,27 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (h *K8SServer) ListDaemonSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+func (s *K8SServer) ListDaemonSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
-	workloads, err := h.DaemonSetService.List(ctx, req.Namespace)
+	endpoint := "list_daemonsets"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
+	workloads, err := s.DaemonSetService.List(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/api/daemonset_handler.go
+++ b/internal/api/daemonset_handler.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (h *K8SServer) ListDaemonSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := h.DaemonSetService.List(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/deployment_handler.go
+++ b/internal/api/deployment_handler.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (s *K8SServer) ListDeployments(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := s.DeploymentService.ListDeployment(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/deployment_handler.go
+++ b/internal/api/deployment_handler.go
@@ -3,13 +3,28 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (s *K8SServer) ListDeployments(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
+	endpoint := "list_deployments"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
+
 	workloads, err := s.DeploymentService.ListDeployment(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/api/job_handler.go
+++ b/internal/api/job_handler.go
@@ -3,16 +3,27 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (s *K8SServer) ListJobs(
-	ctx context.Context,
-	req *pb.NamespaceRequest,
-) (*pb.WorkloadListResponse, error) {
+func (s *K8SServer) ListJobs(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
+	endpoint := "list_jobs"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
 	workloads, err := s.JobService.List(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/api/job_handler.go
+++ b/internal/api/job_handler.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (s *K8SServer) ListJobs(
+	ctx context.Context,
+	req *pb.NamespaceRequest,
+) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := s.JobService.List(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/k8s_handler.go
+++ b/internal/api/k8s_handler.go
@@ -12,11 +12,14 @@ import (
 
 type K8SServer struct {
 	pb.UnimplementedK8SInfoServer
-	PodService     *service.PodService
-	NodeService    *service.NodeService
-	EventService   *service.EventService
-	PodMetService  *service.PodMetService
-	NodeMetService *service.NodeMetService
+	PodService        *service.PodService
+	NodeService       *service.NodeService
+	EventService      *service.EventService
+	PodMetService     *service.PodMetService
+	NodeMetService    *service.NodeMetService
+	DeploymentService *service.DeploymentService
+	ReplicaSetservice *service.ReplicaSetService
+	DaemonSetService  *service.DaemonSetService
 }
 
 func (s *K8SServer) ListPods(ctx context.Context, req *pb.NamespaceRequest) (*pb.PodListResponse, error) {

--- a/internal/api/k8s_handler.go
+++ b/internal/api/k8s_handler.go
@@ -12,14 +12,15 @@ import (
 
 type K8SServer struct {
 	pb.UnimplementedK8SInfoServer
-	PodService        *service.PodService
-	NodeService       *service.NodeService
-	EventService      *service.EventService
-	PodMetService     *service.PodMetService
-	NodeMetService    *service.NodeMetService
-	DeploymentService *service.DeploymentService
-	ReplicaSetservice *service.ReplicaSetService
-	DaemonSetService  *service.DaemonSetService
+	PodService         *service.PodService
+	NodeService        *service.NodeService
+	EventService       *service.EventService
+	PodMetService      *service.PodMetService
+	NodeMetService     *service.NodeMetService
+	DeploymentService  *service.DeploymentService
+	ReplicaSetservice  *service.ReplicaSetService
+	DaemonSetService   *service.DaemonSetService
+	StatefulSetService *service.StatefulSetService
 }
 
 func (s *K8SServer) ListPods(ctx context.Context, req *pb.NamespaceRequest) (*pb.PodListResponse, error) {

--- a/internal/api/k8s_handler.go
+++ b/internal/api/k8s_handler.go
@@ -21,6 +21,8 @@ type K8SServer struct {
 	ReplicaSetservice  *service.ReplicaSetService
 	DaemonSetService   *service.DaemonSetService
 	StatefulSetService *service.StatefulSetService
+	JobService         *service.JobService
+	CronJobService     *service.CronJobService
 }
 
 func (s *K8SServer) ListPods(ctx context.Context, req *pb.NamespaceRequest) (*pb.PodListResponse, error) {

--- a/internal/api/replicaset_handler.go
+++ b/internal/api/replicaset_handler.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (s *K8SServer) ListReplicaSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := s.ReplicaSetservice.ListReplicaSet(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/replicaset_handler.go
+++ b/internal/api/replicaset_handler.go
@@ -3,13 +3,27 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (s *K8SServer) ListReplicaSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
+	endpoint := "list_replicasets"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
 	workloads, err := s.ReplicaSetservice.ListReplicaSet(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/api/statefulset_handler.go
+++ b/internal/api/statefulset_handler.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+)
+
+func (h *K8SServer) ListStatefulSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+
+	workloads, err := h.StatefulSetService.List(ctx, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.WorkloadListResponse{
+		Workloads: workloads,
+	}, nil
+}

--- a/internal/api/statefulset_handler.go
+++ b/internal/api/statefulset_handler.go
@@ -3,13 +3,27 @@ package api
 import (
 	"context"
 
+	"github.com/Mujib-Ahasan/Rampaz/internal/metrics"
 	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (h *K8SServer) ListStatefulSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
+func (s *K8SServer) ListStatefulSets(ctx context.Context, req *pb.NamespaceRequest) (*pb.WorkloadListResponse, error) {
 
-	workloads, err := h.StatefulSetService.List(ctx, req.Namespace)
+	endpoint := "list_statefulsets"
+	status := "success"
+	timer := prometheus.NewTimer(
+		metrics.RequestLatency.WithLabelValues(endpoint),
+	)
+	defer func() {
+		timer.ObserveDuration()
+		metrics.APIRequests.
+			WithLabelValues(endpoint, status).
+			Inc()
+	}()
+	workloads, err := s.StatefulSetService.List(ctx, req.Namespace)
 	if err != nil {
+		status = "error"
 		return nil, err
 	}
 

--- a/internal/kubernetes/cronjob_client.go
+++ b/internal/kubernetes/cronjob_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type CronJobClient struct {
+	client kubernetes.Interface
+}
+
+func NewCronJobClient(client kubernetes.Interface) *CronJobClient {
+	return &CronJobClient{client: client}
+}
+
+func (c *CronJobClient) List(ctx context.Context, namespace string) ([]batchv1.CronJob, error) {
+	list, err := c.client.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/kubernetes/daemonset_client.go
+++ b/internal/kubernetes/daemonset_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type DaemonSetClient struct {
+	client kubernetes.Interface
+}
+
+func NewDaemonSetClient(client kubernetes.Interface) *DaemonSetClient {
+	return &DaemonSetClient{client: client}
+}
+
+func (c *DaemonSetClient) List(ctx context.Context, namespace string) ([]appsv1.DaemonSet, error) {
+	list, err := c.client.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/kubernetes/deployment_client.go
+++ b/internal/kubernetes/deployment_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type DeploymentClient struct {
+	client kubernetes.Interface
+}
+
+func NewDeploymentClient(client kubernetes.Interface) *DeploymentClient {
+	return &DeploymentClient{client: client}
+}
+
+func (c *DeploymentClient) List(ctx context.Context, namespace string) ([]appsv1.Deployment, error) {
+	list, err := c.client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/kubernetes/job_client.go
+++ b/internal/kubernetes/job_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type JobClient struct {
+	client kubernetes.Interface
+}
+
+func NewJobClient(client kubernetes.Interface) *JobClient {
+	return &JobClient{client: client}
+}
+
+func (c *JobClient) List(ctx context.Context, namespace string) ([]batchv1.Job, error) {
+	list, err := c.client.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/kubernetes/pod_client.go
+++ b/internal/kubernetes/pod_client.go
@@ -17,7 +17,5 @@ func NewPodClient(c *kubernetes.Clientset) *PodClient {
 }
 
 func (p *PodClient) ListPods(ctx context.Context, namespace string) (*corev1.PodList, error) {
-	return p.client.CoreV1().
-		Pods(namespace).
-		List(ctx, metav1.ListOptions{})
+	return p.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 }

--- a/internal/kubernetes/replicaset_client.go
+++ b/internal/kubernetes/replicaset_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ReplicaSetClient struct {
+	client kubernetes.Interface
+}
+
+func NewReplicaSetClient(client kubernetes.Interface) *ReplicaSetClient {
+	return &ReplicaSetClient{client: client}
+}
+
+func (c *ReplicaSetClient) List(ctx context.Context, namespace string) ([]appsv1.ReplicaSet, error) {
+	list, err := c.client.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/kubernetes/statefulset_client.go
+++ b/internal/kubernetes/statefulset_client.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type StatefulSetClient struct {
+	client kubernetes.Interface
+}
+
+func NewStatefulSetClient(client kubernetes.Interface) *StatefulSetClient {
+	return &StatefulSetClient{client: client}
+}
+
+func (c *StatefulSetClient) List(ctx context.Context, namespace string) ([]appsv1.StatefulSet, error) {
+	list, err := c.client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}

--- a/internal/service/cronjob_service.go
+++ b/internal/service/cronjob_service.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+type CronJobService struct {
+	client *kubernetes.CronJobClient
+}
+
+func NewCronJobService(client *kubernetes.CronJobClient) *CronJobService {
+	return &CronJobService{client: client}
+}
+
+func (s *CronJobService) List(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	cronJobs, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, cj := range cronJobs {
+		result = append(result, transformCronJob(&cj))
+	}
+
+	return result, nil
+}
+
+func transformCronJob(cj *batchv1.CronJob) *pb.Workload {
+	var lastSchedule string
+	if cj.Status.LastScheduleTime != nil {
+		lastSchedule = cj.Status.LastScheduleTime.Time.String()
+	}
+
+	return &pb.Workload{
+		Name:      cj.Name,
+		Namespace: cj.Namespace,
+
+		Schedule:         cj.Spec.Schedule,
+		LastScheduleTime: lastSchedule,
+		Active:           int32(len(cj.Status.Active)),
+
+		Labels: cj.Labels,
+		Owner:  extractOwner(cj.OwnerReferences),
+		Age:    calculateAge(cj.CreationTimestamp.Time),
+	}
+}

--- a/internal/service/daemonset_service.go
+++ b/internal/service/daemonset_service.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type DaemonSetService struct {
+	client *kubernetes.DaemonSetClient
+}
+
+func NewDaemonSetService(client *kubernetes.DaemonSetClient) *DaemonSetService {
+	return &DaemonSetService{client: client}
+}
+
+func (s *DaemonSetService) List(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	daemonSets, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, ds := range daemonSets {
+		result = append(result, transformDaemonSet(&ds))
+	}
+
+	return result, nil
+}
+
+func transformDaemonSet(ds *appsv1.DaemonSet) *pb.Workload {
+	conditions := extractDaemonSetConditions(ds.Status.Conditions)
+
+	return &pb.Workload{
+		Name:              ds.Name,
+		Namespace:         ds.Namespace,
+		DesiredReplicas:   ds.Status.DesiredNumberScheduled,
+		ReadyReplicas:     ds.Status.NumberReady,
+		AvailableReplicas: ds.Status.NumberAvailable,
+		UpdatedReplicas:   ds.Status.UpdatedNumberScheduled,
+		Labels:            ds.Labels,
+		Conditions:        conditions,
+		Owner:             extractOwner(ds.OwnerReferences),
+		Age:               calculateAge(ds.CreationTimestamp.Time),
+	}
+}
+
+func extractDaemonSetConditions(conds []appsv1.DaemonSetCondition) []string {
+	var result []string
+	for _, c := range conds {
+		result = append(result, string(c.Type)+"="+string(c.Status))
+	}
+	return result
+}

--- a/internal/service/deployment_service.go
+++ b/internal/service/deployment_service.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DeploymentService struct {
+	client *kubernetes.DeploymentClient
+}
+
+func NewDeploymentService(client *kubernetes.DeploymentClient) *DeploymentService {
+	return &DeploymentService{client: client}
+}
+
+func (s *DeploymentService) ListDeployment(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	deployments, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, d := range deployments {
+		result = append(result, transformDeployment(&d))
+	}
+
+	return result, nil
+}
+
+func transformDeployment(d *appsv1.Deployment) *pb.Workload {
+	var desired int32
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+
+	conditions := extractConditions(d.Status.Conditions)
+
+	return &pb.Workload{
+		Name:              d.Name,
+		Namespace:         d.Namespace,
+		DesiredReplicas:   desired,
+		ReadyReplicas:     d.Status.ReadyReplicas,
+		AvailableReplicas: d.Status.AvailableReplicas,
+		UpdatedReplicas:   d.Status.UpdatedReplicas,
+		Labels:            d.Labels,
+		Conditions:        conditions,
+		Owner:             extractOwner(d.OwnerReferences),
+		Age:               calculateAge(d.CreationTimestamp.Time),
+	}
+}
+
+func extractConditions(conds []appsv1.DeploymentCondition) []string {
+	var result []string
+	for _, c := range conds {
+		result = append(result, string(c.Type)+"="+string(c.Status))
+	}
+	return result
+}
+
+func extractOwner(refs []metav1.OwnerReference) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	return refs[0].Kind + "/" + refs[0].Name
+}
+
+func calculateAge(t time.Time) string {
+	return time.Since(t).Round(time.Second).String()
+}

--- a/internal/service/job_service.go
+++ b/internal/service/job_service.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+type JobService struct {
+	client *kubernetes.JobClient
+}
+
+func NewJobService(client *kubernetes.JobClient) *JobService {
+	return &JobService{client: client}
+}
+
+func (s *JobService) List(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	jobs, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, job := range jobs {
+		result = append(result, transformJob(&job))
+	}
+
+	return result, nil
+}
+
+func transformJob(job *batchv1.Job) *pb.Workload {
+	conditions := extractJobConditions(job.Status.Conditions)
+
+	return &pb.Workload{
+		Name:       job.Name,
+		Namespace:  job.Namespace,
+		Active:     job.Status.Active,
+		Succeeded:  job.Status.Succeeded,
+		Failed:     job.Status.Failed,
+		Labels:     job.Labels,
+		Conditions: conditions,
+		Owner:      extractOwner(job.OwnerReferences),
+		Age:        calculateAge(job.CreationTimestamp.Time),
+	}
+}
+
+func extractJobConditions(conds []batchv1.JobCondition) []string {
+	var result []string
+	for _, c := range conds {
+		result = append(result, string(c.Type)+"="+string(c.Status))
+	}
+	return result
+}

--- a/internal/service/replicaset_service.go
+++ b/internal/service/replicaset_service.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type ReplicaSetService struct {
+	client *kubernetes.ReplicaSetClient
+}
+
+func NewReplicaSetService(client *kubernetes.ReplicaSetClient) *ReplicaSetService {
+	return &ReplicaSetService{client: client}
+}
+
+func (s *ReplicaSetService) ListReplicaSet(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	replicaSets, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, rs := range replicaSets {
+		result = append(result, transformReplicaSet(&rs))
+	}
+
+	return result, nil
+}
+
+func transformReplicaSet(rs *appsv1.ReplicaSet) *pb.Workload {
+	var desired int32
+	if rs.Spec.Replicas != nil {
+		desired = *rs.Spec.Replicas
+	}
+
+	conditions := extractReplicaSetConditions(rs.Status.Conditions)
+
+	return &pb.Workload{
+		Name:              rs.Name,
+		Namespace:         rs.Namespace,
+		DesiredReplicas:   desired,
+		ReadyReplicas:     rs.Status.ReadyReplicas,
+		AvailableReplicas: rs.Status.AvailableReplicas,
+		Labels:            rs.Labels,
+		Conditions:        conditions,
+		Owner:             extractOwner(rs.OwnerReferences),
+		Age:               calculateAge(rs.CreationTimestamp.Time),
+	}
+}
+
+func extractReplicaSetConditions(conds []appsv1.ReplicaSetCondition) []string {
+	var result []string
+	for _, c := range conds {
+		result = append(result, string(c.Type)+"="+string(c.Status))
+	}
+	return result
+}

--- a/internal/service/statefulset_service.go
+++ b/internal/service/statefulset_service.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Mujib-Ahasan/Rampaz/internal/kubernetes"
+	pb "github.com/Mujib-Ahasan/Rampaz/proto"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type StatefulSetService struct {
+	client *kubernetes.StatefulSetClient
+}
+
+func NewStatefulSetService(client *kubernetes.StatefulSetClient) *StatefulSetService {
+	return &StatefulSetService{client: client}
+}
+
+func (s *StatefulSetService) List(ctx context.Context, namespace string) ([]*pb.Workload, error) {
+	statefulSets, err := s.client.List(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*pb.Workload
+
+	for _, ss := range statefulSets {
+		result = append(result, transformStatefulSet(&ss))
+	}
+
+	return result, nil
+}
+
+func transformStatefulSet(ss *appsv1.StatefulSet) *pb.Workload {
+	var desired int32
+	if ss.Spec.Replicas != nil {
+		desired = *ss.Spec.Replicas
+	}
+
+	conditions := extractStatefulSetConditions(ss.Status.Conditions)
+
+	return &pb.Workload{
+		Name:              ss.Name,
+		Namespace:         ss.Namespace,
+		DesiredReplicas:   desired,
+		ReadyReplicas:     ss.Status.ReadyReplicas,
+		AvailableReplicas: ss.Status.CurrentReplicas,
+		UpdatedReplicas:   ss.Status.UpdatedReplicas,
+		Labels:            ss.Labels,
+		Conditions:        conditions,
+		Owner:             extractOwner(ss.OwnerReferences),
+		Age:               calculateAge(ss.CreationTimestamp.Time),
+	}
+}
+
+func extractStatefulSetConditions(conds []appsv1.StatefulSetCondition) []string {
+	var result []string
+	for _, c := range conds {
+		result = append(result, string(c.Type)+"="+string(c.Status))
+	}
+	return result
+}

--- a/proto/rampaz.pb.go
+++ b/proto/rampaz.pb.go
@@ -2,18 +2,17 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v6.33.4
-// source: proto/rampaz.proto
+// source: rampaz.proto
 
 package proto
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -32,7 +31,7 @@ type NamespaceRequest struct {
 
 func (x *NamespaceRequest) Reset() {
 	*x = NamespaceRequest{}
-	mi := &file_proto_rampaz_proto_msgTypes[0]
+	mi := &file_rampaz_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +43,7 @@ func (x *NamespaceRequest) String() string {
 func (*NamespaceRequest) ProtoMessage() {}
 
 func (x *NamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[0]
+	mi := &file_rampaz_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +56,7 @@ func (x *NamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceRequest.ProtoReflect.Descriptor instead.
 func (*NamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{0}
+	return file_rampaz_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *NamespaceRequest) GetNamespace() string {
@@ -76,7 +75,7 @@ type PodRequest struct {
 
 func (x *PodRequest) Reset() {
 	*x = PodRequest{}
-	mi := &file_proto_rampaz_proto_msgTypes[1]
+	mi := &file_rampaz_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -88,7 +87,7 @@ func (x *PodRequest) String() string {
 func (*PodRequest) ProtoMessage() {}
 
 func (x *PodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[1]
+	mi := &file_rampaz_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -101,7 +100,7 @@ func (x *PodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PodRequest.ProtoReflect.Descriptor instead.
 func (*PodRequest) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{1}
+	return file_rampaz_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *PodRequest) GetNamespace() string {
@@ -123,7 +122,7 @@ type PodStatsResponse struct {
 
 func (x *PodStatsResponse) Reset() {
 	*x = PodStatsResponse{}
-	mi := &file_proto_rampaz_proto_msgTypes[2]
+	mi := &file_rampaz_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -135,7 +134,7 @@ func (x *PodStatsResponse) String() string {
 func (*PodStatsResponse) ProtoMessage() {}
 
 func (x *PodStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[2]
+	mi := &file_rampaz_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -148,7 +147,7 @@ func (x *PodStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PodStatsResponse.ProtoReflect.Descriptor instead.
 func (*PodStatsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{2}
+	return file_rampaz_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PodStatsResponse) GetName() string {
@@ -191,7 +190,7 @@ type Pod struct {
 
 func (x *Pod) Reset() {
 	*x = Pod{}
-	mi := &file_proto_rampaz_proto_msgTypes[3]
+	mi := &file_rampaz_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -203,7 +202,7 @@ func (x *Pod) String() string {
 func (*Pod) ProtoMessage() {}
 
 func (x *Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[3]
+	mi := &file_rampaz_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -216,7 +215,7 @@ func (x *Pod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Pod.ProtoReflect.Descriptor instead.
 func (*Pod) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{3}
+	return file_rampaz_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Pod) GetName() string {
@@ -256,7 +255,7 @@ type PodListResponse struct {
 
 func (x *PodListResponse) Reset() {
 	*x = PodListResponse{}
-	mi := &file_proto_rampaz_proto_msgTypes[4]
+	mi := &file_rampaz_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -268,7 +267,7 @@ func (x *PodListResponse) String() string {
 func (*PodListResponse) ProtoMessage() {}
 
 func (x *PodListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[4]
+	mi := &file_rampaz_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -281,7 +280,7 @@ func (x *PodListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PodListResponse.ProtoReflect.Descriptor instead.
 func (*PodListResponse) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{4}
+	return file_rampaz_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PodListResponse) GetPods() []*Pod {
@@ -300,7 +299,7 @@ type NodeRequest struct {
 
 func (x *NodeRequest) Reset() {
 	*x = NodeRequest{}
-	mi := &file_proto_rampaz_proto_msgTypes[5]
+	mi := &file_rampaz_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -312,7 +311,7 @@ func (x *NodeRequest) String() string {
 func (*NodeRequest) ProtoMessage() {}
 
 func (x *NodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[5]
+	mi := &file_rampaz_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -325,7 +324,7 @@ func (x *NodeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeRequest.ProtoReflect.Descriptor instead.
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{5}
+	return file_rampaz_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *NodeRequest) GetNodeName() string {
@@ -346,7 +345,7 @@ type NodeStatsResponse struct {
 
 func (x *NodeStatsResponse) Reset() {
 	*x = NodeStatsResponse{}
-	mi := &file_proto_rampaz_proto_msgTypes[6]
+	mi := &file_rampaz_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -358,7 +357,7 @@ func (x *NodeStatsResponse) String() string {
 func (*NodeStatsResponse) ProtoMessage() {}
 
 func (x *NodeStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[6]
+	mi := &file_rampaz_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -371,7 +370,7 @@ func (x *NodeStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeStatsResponse.ProtoReflect.Descriptor instead.
 func (*NodeStatsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{6}
+	return file_rampaz_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *NodeStatsResponse) GetName() string {
@@ -407,7 +406,7 @@ type EventResponse struct {
 
 func (x *EventResponse) Reset() {
 	*x = EventResponse{}
-	mi := &file_proto_rampaz_proto_msgTypes[7]
+	mi := &file_rampaz_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -419,7 +418,7 @@ func (x *EventResponse) String() string {
 func (*EventResponse) ProtoMessage() {}
 
 func (x *EventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_rampaz_proto_msgTypes[7]
+	mi := &file_rampaz_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -432,7 +431,7 @@ func (x *EventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventResponse.ProtoReflect.Descriptor instead.
 func (*EventResponse) Descriptor() ([]byte, []int) {
-	return file_proto_rampaz_proto_rawDescGZIP(), []int{7}
+	return file_rampaz_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *EventResponse) GetType() string {
@@ -463,11 +462,215 @@ func (x *EventResponse) GetInvolvedObject() string {
 	return ""
 }
 
-var File_proto_rampaz_proto protoreflect.FileDescriptor
+type Workload struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Name      string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// Replica-related fields (not all apply to every workload)
+	DesiredReplicas   int32 `protobuf:"varint,3,opt,name=desiredReplicas,proto3" json:"desiredReplicas,omitempty"`
+	ReadyReplicas     int32 `protobuf:"varint,4,opt,name=readyReplicas,proto3" json:"readyReplicas,omitempty"`
+	AvailableReplicas int32 `protobuf:"varint,5,opt,name=availableReplicas,proto3" json:"availableReplicas,omitempty"`
+	UpdatedReplicas   int32 `protobuf:"varint,6,opt,name=updatedReplicas,proto3" json:"updatedReplicas,omitempty"`
+	// Job-specific fields
+	Active    int32 `protobuf:"varint,7,opt,name=active,proto3" json:"active,omitempty"`
+	Succeeded int32 `protobuf:"varint,8,opt,name=succeeded,proto3" json:"succeeded,omitempty"`
+	Failed    int32 `protobuf:"varint,9,opt,name=failed,proto3" json:"failed,omitempty"`
+	// CronJob-specific fields
+	Schedule         string `protobuf:"bytes,10,opt,name=schedule,proto3" json:"schedule,omitempty"`
+	LastScheduleTime string `protobuf:"bytes,11,opt,name=lastScheduleTime,proto3" json:"lastScheduleTime,omitempty"`
+	// Metadata
+	Labels        map[string]string `protobuf:"bytes,12,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Conditions    []string          `protobuf:"bytes,13,rep,name=conditions,proto3" json:"conditions,omitempty"`
+	Owner         string            `protobuf:"bytes,14,opt,name=owner,proto3" json:"owner,omitempty"`
+	Age           string            `protobuf:"bytes,15,opt,name=age,proto3" json:"age,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
 
-const file_proto_rampaz_proto_rawDesc = "" +
+func (x *Workload) Reset() {
+	*x = Workload{}
+	mi := &file_rampaz_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Workload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Workload) ProtoMessage() {}
+
+func (x *Workload) ProtoReflect() protoreflect.Message {
+	mi := &file_rampaz_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Workload.ProtoReflect.Descriptor instead.
+func (*Workload) Descriptor() ([]byte, []int) {
+	return file_rampaz_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *Workload) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Workload) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *Workload) GetDesiredReplicas() int32 {
+	if x != nil {
+		return x.DesiredReplicas
+	}
+	return 0
+}
+
+func (x *Workload) GetReadyReplicas() int32 {
+	if x != nil {
+		return x.ReadyReplicas
+	}
+	return 0
+}
+
+func (x *Workload) GetAvailableReplicas() int32 {
+	if x != nil {
+		return x.AvailableReplicas
+	}
+	return 0
+}
+
+func (x *Workload) GetUpdatedReplicas() int32 {
+	if x != nil {
+		return x.UpdatedReplicas
+	}
+	return 0
+}
+
+func (x *Workload) GetActive() int32 {
+	if x != nil {
+		return x.Active
+	}
+	return 0
+}
+
+func (x *Workload) GetSucceeded() int32 {
+	if x != nil {
+		return x.Succeeded
+	}
+	return 0
+}
+
+func (x *Workload) GetFailed() int32 {
+	if x != nil {
+		return x.Failed
+	}
+	return 0
+}
+
+func (x *Workload) GetSchedule() string {
+	if x != nil {
+		return x.Schedule
+	}
+	return ""
+}
+
+func (x *Workload) GetLastScheduleTime() string {
+	if x != nil {
+		return x.LastScheduleTime
+	}
+	return ""
+}
+
+func (x *Workload) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *Workload) GetConditions() []string {
+	if x != nil {
+		return x.Conditions
+	}
+	return nil
+}
+
+func (x *Workload) GetOwner() string {
+	if x != nil {
+		return x.Owner
+	}
+	return ""
+}
+
+func (x *Workload) GetAge() string {
+	if x != nil {
+		return x.Age
+	}
+	return ""
+}
+
+type WorkloadListResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Workloads     []*Workload            `protobuf:"bytes,1,rep,name=workloads,proto3" json:"workloads,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkloadListResponse) Reset() {
+	*x = WorkloadListResponse{}
+	mi := &file_rampaz_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkloadListResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkloadListResponse) ProtoMessage() {}
+
+func (x *WorkloadListResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_rampaz_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkloadListResponse.ProtoReflect.Descriptor instead.
+func (*WorkloadListResponse) Descriptor() ([]byte, []int) {
+	return file_rampaz_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *WorkloadListResponse) GetWorkloads() []*Workload {
+	if x != nil {
+		return x.Workloads
+	}
+	return nil
+}
+
+var File_rampaz_proto protoreflect.FileDescriptor
+
+const file_rampaz_proto_rawDesc = "" +
 	"\n" +
-	"\x12proto/rampaz.proto\x12\ak8sinfo\x1a\x1bgoogle/protobuf/empty.proto\"0\n" +
+	"\frampaz.proto\x12\ak8sinfo\x1a\x1bgoogle/protobuf/empty.proto\"0\n" +
 	"\x10NamespaceRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\"*\n" +
 	"\n" +
@@ -495,77 +698,124 @@ const file_proto_rampaz_proto_rawDesc = "" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12&\n" +
-	"\x0einvolvedObject\x18\x04 \x01(\tR\x0einvolvedObject2\xdb\x02\n" +
+	"\x0einvolvedObject\x18\x04 \x01(\tR\x0einvolvedObject\"\xb4\x04\n" +
+	"\bWorkload\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12(\n" +
+	"\x0fdesiredReplicas\x18\x03 \x01(\x05R\x0fdesiredReplicas\x12$\n" +
+	"\rreadyReplicas\x18\x04 \x01(\x05R\rreadyReplicas\x12,\n" +
+	"\x11availableReplicas\x18\x05 \x01(\x05R\x11availableReplicas\x12(\n" +
+	"\x0fupdatedReplicas\x18\x06 \x01(\x05R\x0fupdatedReplicas\x12\x16\n" +
+	"\x06active\x18\a \x01(\x05R\x06active\x12\x1c\n" +
+	"\tsucceeded\x18\b \x01(\x05R\tsucceeded\x12\x16\n" +
+	"\x06failed\x18\t \x01(\x05R\x06failed\x12\x1a\n" +
+	"\bschedule\x18\n" +
+	" \x01(\tR\bschedule\x12*\n" +
+	"\x10lastScheduleTime\x18\v \x01(\tR\x10lastScheduleTime\x125\n" +
+	"\x06labels\x18\f \x03(\v2\x1d.k8sinfo.Workload.LabelsEntryR\x06labels\x12\x1e\n" +
+	"\n" +
+	"conditions\x18\r \x03(\tR\n" +
+	"conditions\x12\x14\n" +
+	"\x05owner\x18\x0e \x01(\tR\x05owner\x12\x10\n" +
+	"\x03age\x18\x0f \x01(\tR\x03age\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
+	"\x14WorkloadListResponse\x12/\n" +
+	"\tworkloads\x18\x01 \x03(\v2\x11.k8sinfo.WorkloadR\tworkloads2\x9f\x06\n" +
 	"\aK8sInfo\x12?\n" +
 	"\bListPods\x12\x19.k8sinfo.NamespaceRequest\x1a\x18.k8sinfo.PodListResponse\x12@\n" +
 	"\fGetNodeStats\x12\x14.k8sinfo.NodeRequest\x1a\x1a.k8sinfo.NodeStatsResponse\x12?\n" +
 	"\vGetPodStats\x12\x13.k8sinfo.PodRequest\x1a\x19.k8sinfo.PodStatsResponse0\x01\x12J\n" +
 	"\x14GetNodeRealTimeStats\x12\x14.k8sinfo.NodeRequest\x1a\x1a.k8sinfo.NodeStatsResponse0\x01\x12@\n" +
-	"\fStreamEvents\x12\x16.google.protobuf.Empty\x1a\x16.k8sinfo.EventResponse0\x01B&Z$github.com/Mujib-Ahasan/Rampaz/protob\x06proto3"
+	"\fStreamEvents\x12\x16.google.protobuf.Empty\x1a\x16.k8sinfo.EventResponse0\x01\x12K\n" +
+	"\x0fListDeployments\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponse\x12K\n" +
+	"\x0fListReplicaSets\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponse\x12L\n" +
+	"\x10ListStatefulSets\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponse\x12J\n" +
+	"\x0eListDaemonSets\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponse\x12D\n" +
+	"\bListJobs\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponse\x12H\n" +
+	"\fListCronJobs\x12\x19.k8sinfo.NamespaceRequest\x1a\x1d.k8sinfo.WorkloadListResponseB&Z$github.com/Mujib-Ahasan/Rampaz/protob\x06proto3"
 
 var (
-	file_proto_rampaz_proto_rawDescOnce sync.Once
-	file_proto_rampaz_proto_rawDescData []byte
+	file_rampaz_proto_rawDescOnce sync.Once
+	file_rampaz_proto_rawDescData []byte
 )
 
-func file_proto_rampaz_proto_rawDescGZIP() []byte {
-	file_proto_rampaz_proto_rawDescOnce.Do(func() {
-		file_proto_rampaz_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_proto_rampaz_proto_rawDesc), len(file_proto_rampaz_proto_rawDesc)))
+func file_rampaz_proto_rawDescGZIP() []byte {
+	file_rampaz_proto_rawDescOnce.Do(func() {
+		file_rampaz_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_rampaz_proto_rawDesc), len(file_rampaz_proto_rawDesc)))
 	})
-	return file_proto_rampaz_proto_rawDescData
+	return file_rampaz_proto_rawDescData
 }
 
-var file_proto_rampaz_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
-var file_proto_rampaz_proto_goTypes = []any{
-	(*NamespaceRequest)(nil),  // 0: k8sinfo.NamespaceRequest
-	(*PodRequest)(nil),        // 1: k8sinfo.PodRequest
-	(*PodStatsResponse)(nil),  // 2: k8sinfo.PodStatsResponse
-	(*Pod)(nil),               // 3: k8sinfo.Pod
-	(*PodListResponse)(nil),   // 4: k8sinfo.PodListResponse
-	(*NodeRequest)(nil),       // 5: k8sinfo.NodeRequest
-	(*NodeStatsResponse)(nil), // 6: k8sinfo.NodeStatsResponse
-	(*EventResponse)(nil),     // 7: k8sinfo.EventResponse
-	(*emptypb.Empty)(nil),     // 8: google.protobuf.Empty
+var file_rampaz_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_rampaz_proto_goTypes = []any{
+	(*NamespaceRequest)(nil),     // 0: k8sinfo.NamespaceRequest
+	(*PodRequest)(nil),           // 1: k8sinfo.PodRequest
+	(*PodStatsResponse)(nil),     // 2: k8sinfo.PodStatsResponse
+	(*Pod)(nil),                  // 3: k8sinfo.Pod
+	(*PodListResponse)(nil),      // 4: k8sinfo.PodListResponse
+	(*NodeRequest)(nil),          // 5: k8sinfo.NodeRequest
+	(*NodeStatsResponse)(nil),    // 6: k8sinfo.NodeStatsResponse
+	(*EventResponse)(nil),        // 7: k8sinfo.EventResponse
+	(*Workload)(nil),             // 8: k8sinfo.Workload
+	(*WorkloadListResponse)(nil), // 9: k8sinfo.WorkloadListResponse
+	nil,                          // 10: k8sinfo.Workload.LabelsEntry
+	(*emptypb.Empty)(nil),        // 11: google.protobuf.Empty
 }
-var file_proto_rampaz_proto_depIdxs = []int32{
-	3, // 0: k8sinfo.PodListResponse.pods:type_name -> k8sinfo.Pod
-	0, // 1: k8sinfo.K8sInfo.ListPods:input_type -> k8sinfo.NamespaceRequest
-	5, // 2: k8sinfo.K8sInfo.GetNodeStats:input_type -> k8sinfo.NodeRequest
-	1, // 3: k8sinfo.K8sInfo.GetPodStats:input_type -> k8sinfo.PodRequest
-	5, // 4: k8sinfo.K8sInfo.GetNodeRealTimeStats:input_type -> k8sinfo.NodeRequest
-	8, // 5: k8sinfo.K8sInfo.StreamEvents:input_type -> google.protobuf.Empty
-	4, // 6: k8sinfo.K8sInfo.ListPods:output_type -> k8sinfo.PodListResponse
-	6, // 7: k8sinfo.K8sInfo.GetNodeStats:output_type -> k8sinfo.NodeStatsResponse
-	2, // 8: k8sinfo.K8sInfo.GetPodStats:output_type -> k8sinfo.PodStatsResponse
-	6, // 9: k8sinfo.K8sInfo.GetNodeRealTimeStats:output_type -> k8sinfo.NodeStatsResponse
-	7, // 10: k8sinfo.K8sInfo.StreamEvents:output_type -> k8sinfo.EventResponse
-	6, // [6:11] is the sub-list for method output_type
-	1, // [1:6] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+var file_rampaz_proto_depIdxs = []int32{
+	3,  // 0: k8sinfo.PodListResponse.pods:type_name -> k8sinfo.Pod
+	10, // 1: k8sinfo.Workload.labels:type_name -> k8sinfo.Workload.LabelsEntry
+	8,  // 2: k8sinfo.WorkloadListResponse.workloads:type_name -> k8sinfo.Workload
+	0,  // 3: k8sinfo.K8sInfo.ListPods:input_type -> k8sinfo.NamespaceRequest
+	5,  // 4: k8sinfo.K8sInfo.GetNodeStats:input_type -> k8sinfo.NodeRequest
+	1,  // 5: k8sinfo.K8sInfo.GetPodStats:input_type -> k8sinfo.PodRequest
+	5,  // 6: k8sinfo.K8sInfo.GetNodeRealTimeStats:input_type -> k8sinfo.NodeRequest
+	11, // 7: k8sinfo.K8sInfo.StreamEvents:input_type -> google.protobuf.Empty
+	0,  // 8: k8sinfo.K8sInfo.ListDeployments:input_type -> k8sinfo.NamespaceRequest
+	0,  // 9: k8sinfo.K8sInfo.ListReplicaSets:input_type -> k8sinfo.NamespaceRequest
+	0,  // 10: k8sinfo.K8sInfo.ListStatefulSets:input_type -> k8sinfo.NamespaceRequest
+	0,  // 11: k8sinfo.K8sInfo.ListDaemonSets:input_type -> k8sinfo.NamespaceRequest
+	0,  // 12: k8sinfo.K8sInfo.ListJobs:input_type -> k8sinfo.NamespaceRequest
+	0,  // 13: k8sinfo.K8sInfo.ListCronJobs:input_type -> k8sinfo.NamespaceRequest
+	4,  // 14: k8sinfo.K8sInfo.ListPods:output_type -> k8sinfo.PodListResponse
+	6,  // 15: k8sinfo.K8sInfo.GetNodeStats:output_type -> k8sinfo.NodeStatsResponse
+	2,  // 16: k8sinfo.K8sInfo.GetPodStats:output_type -> k8sinfo.PodStatsResponse
+	6,  // 17: k8sinfo.K8sInfo.GetNodeRealTimeStats:output_type -> k8sinfo.NodeStatsResponse
+	7,  // 18: k8sinfo.K8sInfo.StreamEvents:output_type -> k8sinfo.EventResponse
+	9,  // 19: k8sinfo.K8sInfo.ListDeployments:output_type -> k8sinfo.WorkloadListResponse
+	9,  // 20: k8sinfo.K8sInfo.ListReplicaSets:output_type -> k8sinfo.WorkloadListResponse
+	9,  // 21: k8sinfo.K8sInfo.ListStatefulSets:output_type -> k8sinfo.WorkloadListResponse
+	9,  // 22: k8sinfo.K8sInfo.ListDaemonSets:output_type -> k8sinfo.WorkloadListResponse
+	9,  // 23: k8sinfo.K8sInfo.ListJobs:output_type -> k8sinfo.WorkloadListResponse
+	9,  // 24: k8sinfo.K8sInfo.ListCronJobs:output_type -> k8sinfo.WorkloadListResponse
+	14, // [14:25] is the sub-list for method output_type
+	3,  // [3:14] is the sub-list for method input_type
+	3,  // [3:3] is the sub-list for extension type_name
+	3,  // [3:3] is the sub-list for extension extendee
+	0,  // [0:3] is the sub-list for field type_name
 }
 
-func init() { file_proto_rampaz_proto_init() }
-func file_proto_rampaz_proto_init() {
-	if File_proto_rampaz_proto != nil {
+func init() { file_rampaz_proto_init() }
+func file_rampaz_proto_init() {
+	if File_rampaz_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_rampaz_proto_rawDesc), len(file_proto_rampaz_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_rampaz_proto_rawDesc), len(file_rampaz_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_proto_rampaz_proto_goTypes,
-		DependencyIndexes: file_proto_rampaz_proto_depIdxs,
-		MessageInfos:      file_proto_rampaz_proto_msgTypes,
+		GoTypes:           file_rampaz_proto_goTypes,
+		DependencyIndexes: file_rampaz_proto_depIdxs,
+		MessageInfos:      file_rampaz_proto_msgTypes,
 	}.Build()
-	File_proto_rampaz_proto = out.File
-	file_proto_rampaz_proto_goTypes = nil
-	file_proto_rampaz_proto_depIdxs = nil
+	File_rampaz_proto = out.File
+	file_rampaz_proto_goTypes = nil
+	file_rampaz_proto_depIdxs = nil
 }

--- a/proto/rampaz.proto
+++ b/proto/rampaz.proto
@@ -1,4 +1,4 @@
-syntax="proto3";
+syntax = "proto3";
 
 package k8sinfo;
 
@@ -10,10 +10,15 @@ service K8sInfo {
   rpc ListPods(NamespaceRequest) returns (PodListResponse);
   rpc GetNodeStats(NodeRequest) returns (NodeStatsResponse);
   rpc GetPodStats(PodRequest) returns (stream PodStatsResponse);
-  rpc GetNodeRealTimeStats (NodeRequest) returns (stream NodeStatsResponse);
+  rpc GetNodeRealTimeStats(NodeRequest) returns (stream NodeStatsResponse);
   rpc StreamEvents(google.protobuf.Empty) returns (stream EventResponse);
+  rpc ListDeployments(NamespaceRequest) returns (WorkloadListResponse);
+  rpc ListReplicaSets(NamespaceRequest) returns (WorkloadListResponse);
+  rpc ListStatefulSets(NamespaceRequest) returns (WorkloadListResponse);
+  rpc ListDaemonSets(NamespaceRequest) returns (WorkloadListResponse);
+  rpc ListJobs(NamespaceRequest) returns (WorkloadListResponse);
+  rpc ListCronJobs(NamespaceRequest) returns (WorkloadListResponse);
 }
-
 
 message NamespaceRequest {
   string namespace = 1;
@@ -56,5 +61,35 @@ message EventResponse {
   string reason = 2;
   string message = 3;
   string involvedObject = 4;
+}
+
+message Workload {
+  string name = 1;
+  string namespace = 2;
+
+  // Replica-related fields (not all apply to every workload)
+  int32 desiredReplicas = 3;
+  int32 readyReplicas = 4;
+  int32 availableReplicas = 5;
+  int32 updatedReplicas = 6;
+
+  // Job-specific fields
+  int32 active = 7;
+  int32 succeeded = 8;
+  int32 failed = 9;
+
+  // CronJob-specific fields
+  string schedule = 10;
+  string lastScheduleTime = 11;
+
+  // Metadata
+  map<string, string> labels = 12;
+  repeated string conditions = 13;
+  string owner = 14;
+  string age = 15;
+}
+
+message WorkloadListResponse {
+  repeated Workload workloads = 1;
 }
 

--- a/proto/rampaz_grpc.pb.go
+++ b/proto/rampaz_grpc.pb.go
@@ -2,13 +2,12 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.1
 // - protoc             v6.33.4
-// source: proto/rampaz.proto
+// source: rampaz.proto
 
 package proto
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -26,6 +25,12 @@ const (
 	K8SInfo_GetPodStats_FullMethodName          = "/k8sinfo.K8sInfo/GetPodStats"
 	K8SInfo_GetNodeRealTimeStats_FullMethodName = "/k8sinfo.K8sInfo/GetNodeRealTimeStats"
 	K8SInfo_StreamEvents_FullMethodName         = "/k8sinfo.K8sInfo/StreamEvents"
+	K8SInfo_ListDeployments_FullMethodName      = "/k8sinfo.K8sInfo/ListDeployments"
+	K8SInfo_ListReplicaSets_FullMethodName      = "/k8sinfo.K8sInfo/ListReplicaSets"
+	K8SInfo_ListStatefulSets_FullMethodName     = "/k8sinfo.K8sInfo/ListStatefulSets"
+	K8SInfo_ListDaemonSets_FullMethodName       = "/k8sinfo.K8sInfo/ListDaemonSets"
+	K8SInfo_ListJobs_FullMethodName             = "/k8sinfo.K8sInfo/ListJobs"
+	K8SInfo_ListCronJobs_FullMethodName         = "/k8sinfo.K8sInfo/ListCronJobs"
 )
 
 // K8SInfoClient is the client API for K8SInfo service.
@@ -37,6 +42,12 @@ type K8SInfoClient interface {
 	GetPodStats(ctx context.Context, in *PodRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[PodStatsResponse], error)
 	GetNodeRealTimeStats(ctx context.Context, in *NodeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[NodeStatsResponse], error)
 	StreamEvents(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[EventResponse], error)
+	ListDeployments(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
+	ListReplicaSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
+	ListStatefulSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
+	ListDaemonSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
+	ListJobs(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
+	ListCronJobs(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error)
 }
 
 type k8SInfoClient struct {
@@ -124,6 +135,66 @@ func (c *k8SInfoClient) StreamEvents(ctx context.Context, in *emptypb.Empty, opt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type K8SInfo_StreamEventsClient = grpc.ServerStreamingClient[EventResponse]
 
+func (c *k8SInfoClient) ListDeployments(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListDeployments_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *k8SInfoClient) ListReplicaSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListReplicaSets_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *k8SInfoClient) ListStatefulSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListStatefulSets_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *k8SInfoClient) ListDaemonSets(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListDaemonSets_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *k8SInfoClient) ListJobs(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListJobs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *k8SInfoClient) ListCronJobs(ctx context.Context, in *NamespaceRequest, opts ...grpc.CallOption) (*WorkloadListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WorkloadListResponse)
+	err := c.cc.Invoke(ctx, K8SInfo_ListCronJobs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // K8SInfoServer is the server API for K8SInfo service.
 // All implementations must embed UnimplementedK8SInfoServer
 // for forward compatibility.
@@ -133,6 +204,12 @@ type K8SInfoServer interface {
 	GetPodStats(*PodRequest, grpc.ServerStreamingServer[PodStatsResponse]) error
 	GetNodeRealTimeStats(*NodeRequest, grpc.ServerStreamingServer[NodeStatsResponse]) error
 	StreamEvents(*emptypb.Empty, grpc.ServerStreamingServer[EventResponse]) error
+	ListDeployments(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
+	ListReplicaSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
+	ListStatefulSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
+	ListDaemonSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
+	ListJobs(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
+	ListCronJobs(context.Context, *NamespaceRequest) (*WorkloadListResponse, error)
 	mustEmbedUnimplementedK8SInfoServer()
 }
 
@@ -157,6 +234,24 @@ func (UnimplementedK8SInfoServer) GetNodeRealTimeStats(*NodeRequest, grpc.Server
 }
 func (UnimplementedK8SInfoServer) StreamEvents(*emptypb.Empty, grpc.ServerStreamingServer[EventResponse]) error {
 	return status.Error(codes.Unimplemented, "method StreamEvents not implemented")
+}
+func (UnimplementedK8SInfoServer) ListDeployments(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListDeployments not implemented")
+}
+func (UnimplementedK8SInfoServer) ListReplicaSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListReplicaSets not implemented")
+}
+func (UnimplementedK8SInfoServer) ListStatefulSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListStatefulSets not implemented")
+}
+func (UnimplementedK8SInfoServer) ListDaemonSets(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListDaemonSets not implemented")
+}
+func (UnimplementedK8SInfoServer) ListJobs(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListJobs not implemented")
+}
+func (UnimplementedK8SInfoServer) ListCronJobs(context.Context, *NamespaceRequest) (*WorkloadListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListCronJobs not implemented")
 }
 func (UnimplementedK8SInfoServer) mustEmbedUnimplementedK8SInfoServer() {}
 func (UnimplementedK8SInfoServer) testEmbeddedByValue()                 {}
@@ -248,6 +343,114 @@ func _K8SInfo_StreamEvents_Handler(srv interface{}, stream grpc.ServerStream) er
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type K8SInfo_StreamEventsServer = grpc.ServerStreamingServer[EventResponse]
 
+func _K8SInfo_ListDeployments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListDeployments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListDeployments_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListDeployments(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _K8SInfo_ListReplicaSets_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListReplicaSets(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListReplicaSets_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListReplicaSets(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _K8SInfo_ListStatefulSets_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListStatefulSets(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListStatefulSets_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListStatefulSets(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _K8SInfo_ListDaemonSets_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListDaemonSets(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListDaemonSets_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListDaemonSets(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _K8SInfo_ListJobs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListJobs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListJobs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListJobs(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _K8SInfo_ListCronJobs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NamespaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(K8SInfoServer).ListCronJobs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: K8SInfo_ListCronJobs_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(K8SInfoServer).ListCronJobs(ctx, req.(*NamespaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // K8SInfo_ServiceDesc is the grpc.ServiceDesc for K8SInfo service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -262,6 +465,30 @@ var K8SInfo_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetNodeStats",
 			Handler:    _K8SInfo_GetNodeStats_Handler,
+		},
+		{
+			MethodName: "ListDeployments",
+			Handler:    _K8SInfo_ListDeployments_Handler,
+		},
+		{
+			MethodName: "ListReplicaSets",
+			Handler:    _K8SInfo_ListReplicaSets_Handler,
+		},
+		{
+			MethodName: "ListStatefulSets",
+			Handler:    _K8SInfo_ListStatefulSets_Handler,
+		},
+		{
+			MethodName: "ListDaemonSets",
+			Handler:    _K8SInfo_ListDaemonSets_Handler,
+		},
+		{
+			MethodName: "ListJobs",
+			Handler:    _K8SInfo_ListJobs_Handler,
+		},
+		{
+			MethodName: "ListCronJobs",
+			Handler:    _K8SInfo_ListCronJobs_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{
@@ -281,5 +508,5 @@ var K8SInfo_ServiceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 	},
-	Metadata: "proto/rampaz.proto",
+	Metadata: "rampaz.proto",
 }


### PR DESCRIPTION
## Description

This PR adds support for listing six Kubernetes workload resources: Deployments, ReplicaSets, DaemonSets, StatefulSets, Jobs, and CronJobs.
All resources follow a consistent structure across the gRPC handler, service layer, and response format. Prometheus metrics have been added for all of these endpoints, including request count and latency tracking. The implementation uses the appropriate Kubernetes client APIs (apps/v1 and batch/v1) while keeping the response model unified through WorkloadListResponse.

## Changes Made
- Added ListDeployments
- Added ListReplicaSets
- Added ListDaemonSets
- Added ListStatefulSets
- Added ListJobs
- Added ListCronJobs
- Implemented corresponding service-layer methods
- Added Prometheus metrics (request count and latency) for all six resources
- Maintained consistent workload response structure